### PR TITLE
Add override for org.bouncycastle:bcprov-jdk18on 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.0.2-SNAPSHOT] - Unreleased
 
+### Security
+
+* Update transitive dependency on org.bouncycastle:bcprov-jdk18on to 1.84 to address dependabot-reported vulnerabilities.
+
 ## [4.0.1] - 2025-03-24
 
 ### Security

--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,19 @@
       <artifactId>shiro-core</artifactId>
       <version>2.1.0</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk18on</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- Override bcprov-jdk18on in shiro-core -->
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk18on</artifactId>
+      <version>1.84</version>
     </dependency>
 
     <!-- Override shiro-web in jena-fuseki-main -->


### PR DESCRIPTION
Bump from 1.82 -> 1.84 to address two dependabot alerts