### PR TITLE
Bump commons-lang3 to 3.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 * Update transitive dependency on apache.org.thrift:libthrift to 0.23.0 to address CVE.
+* Update commons-lang3 to 3.20.0
 
 ## [4.0.2] - 2026-04-28
 

--- a/pom.xml
+++ b/pom.xml
@@ -119,12 +119,18 @@
       <groupId>org.apache.velocity</groupId>
       <artifactId>velocity-engine-core</artifactId>
       <version>2.4.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.18.0</version>
+      <version>3.20.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
I noticed that appbase-security overrides the version of commons-lang3 used in the appbase POM, so I thought it would be worth updating it here.