### PR TITLE
pass incoming x-request-id header to remote sparql source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* pass incoming x-request-id header to remote sparql source, obtained via MDC `request_id` parameter
+
 ## [4.0.4] - 2026-05-19
 
 ### Security

--- a/src/main/java/com/epimorphics/appbase/data/impl/RemoteSparqlSource.java
+++ b/src/main/java/com/epimorphics/appbase/data/impl/RemoteSparqlSource.java
@@ -25,9 +25,9 @@ import org.slf4j.LoggerFactory;
 
 import com.epimorphics.appbase.data.SparqlSource;
 import org.apache.jena.query.QueryExecution;
-import org.apache.jena.query.QueryExecutionFactory;
 import org.apache.jena.update.UpdateExecutionFactory;
 import org.apache.jena.update.UpdateRequest;
+import org.slf4j.MDC;
 
 /**
  * Sparql source for querying remote sparql endpoints. Configuration options:
@@ -105,11 +105,16 @@ public class RemoteSparqlSource extends BaseSparqlSource implements SparqlSource
         }
     }
 
+    private static final String MDC_REQUEST_HEADER = "request_id";
+
     @Override
     protected QueryExecution start(String queryString) {
         QueryExecutionHTTPBuilder hs = QueryExecutionHTTP.service(endpoint).query(queryString);
         if (contentType != null) {
             hs.acceptHeader(contentType);
+        }
+        if (MDC.get(MDC_REQUEST_HEADER) != null) {
+            hs.httpHeader("x-request-id", MDC.get(MDC_REQUEST_HEADER));
         }
         HttpClient.Builder clientBldr = HttpClient.newBuilder();
         if (connectTimeout != -1) {


### PR DESCRIPTION
Obtain x-request-id from MDC as set by `LogRequestFilter`. This avoid having to pass context down a very long call chain.

Part of: https://github.com/epimorphics/sapi/issues/28